### PR TITLE
Made platform detection portable (use of "uname -m")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+
+
+## ed4f557 Changed shell from /bin/sh to /bin/bash in all shell scripts
+
+In legacy Linux versions, `/bin/sh` was a link to `/bin/bash`. Nowadays the
+two shells differ. The shell scripts from AMD are in `bash` syntax and
+therefore the change was necessary. 
+
+## 219a078 Added patch for linux kernel version >= 4.15 Incorporates changes from `init_timer()` to `timer_setup()`
+
+With kernel versions starting from 4.15, the interface for using timers was
+changed.
+
+## 97c3f18 Added disclaimer, description and installation instructions
+
+## 7dd9d09 Initial commit

--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ permissions and liability.
 
 ## Description
 
-This patch incorporates the changes from `init_timer()` to `timer_setup()`
-which are necessary in Linux kernel starting from version 4.15. Since it tests
-for the kernel version, it should also run on kernels with versions below
-4.15. The patch has been successfully tested on Ubuntu 18.04.
+As its main feature, this patch incorporates the changes from `init_timer()`
+to `timer_setup()` which are necessary in Linux kernel starting from version
+4.15. Since it tests for the kernel version, it should also run on kernels
+with versions below 4.15. The patch has been successfully tested on Ubuntu
+18.04. More changes came in as users reported problems in other places of the
+AMD RAID driver. For a complete description, see file
+[CHANGELOG.md](https://github.com/martinkarlweber/rcraid-patches/blob/master/CHANGELOG.md).
+
+
 
 ## Patching instructions
 
@@ -26,17 +31,70 @@ downloaded file,
 Download the file `rcraid.patch` from this repository and put it in the same
 folder you saved the above zip file in. Then issue
 
-`patch -p0 < rcraid.patch`
+`patch -p1 < rcraid.patch`
 
-If the output looks like 
+The output looks like:
 
-    patching file driver_sdk/src/rc_init.c
-    patching file driver_sdk/src/rc_mem_ops.c
-    patching file driver_sdk/src/rc_msg.c
+      patching file driver_sdk/install
+      patching file driver_sdk/src/Makefile
+      patching file driver_sdk/src/common_shell
+      patching file driver_sdk/src/install_rh
+      patching file driver_sdk/src/install_suse
+      patching file driver_sdk/src/rc_init.c
+      patching file driver_sdk/src/rc_mem_ops.c
+      patching file driver_sdk/src/rc_msg.c
+      patching file driver_sdk/src/uninstall_rh
+      patching file driver_sdk/src/uninstall_suse
+      patching file driver_sdk/uninstall
 
-Congratulations! You are done. Proceed with the installation as usual.
+Congratulations! You are done with patching. 
 
-## Installing and using patched driver
+## Quick install instructions for Ubuntu 18.04
 
-For a complete set of instructions on how to install and use the AMD RAID
-Linux driver, have a look at [How to dual boot Windows and Ubuntu on AMD RAID](https://www.kwikr.de//Howto_Windows_Ubuntu_AMD-RAID.html).
+[Download the latest Ubuntu 18.04
+image](https://www.ubuntu.com/download/desktop), install it on a USB stick and
+boot it in UEFI mode (turn of CSM module in BIOS). After booting, download
+the official [AMD RAID driver](https://support.amd.com/de-de/download/chipset?os=Linux+x86_64). Open
+a shell and follow these instructions:
+
+      cd Downloads/
+      unzip raid_linux_driver_8_01_00_039_public.zip
+      sudo apt install git
+      git clone https://github.com/martinkarlweber/rcraid-patches.git
+      mv rcraid-patches/rcraid.patch .
+      rm -rf rcraid-patches/
+      patch -p1 < rcraid.patch
+      cd driver_sdk/
+      sudo apt install build-essential
+      sudo /bin/bash ./install
+      sudo rmmod ahci libahci
+      sudo modprobe rcraid
+      dmesg | less
+
+If everything goes well, you will see an output similar to
+
+      rcraid: loading out-of-tree module taints kernel.
+      rcraid: module license 'Proprietary' taints kernel.
+      Disabling lock debugging due to kernel taint
+      rcraid: module verification failed: signature and/or required key missing - tainting kernel
+      scsi host0: AMD, Inc. AMD-RAID
+      scsi 0:0:0:0: Direct-Access     AMD-RAID Array 01         8.1  PQ: 0 ANSI: 5
+      scsi 0:0:24:0: Processor         AMD-RAID Configuration    V1.2 PQ: 0 ANSI: 5
+      scsi 0:1:0:0: CD-ROM            HL-DT-ST DVDRAM GH22NS50  TN03 PQ: 0 ANSI: 0
+      sd 0:0:0:0: Attached scsi generic sg1 type 0
+      sd 0:0:0:0: [sdb] 3905925120 512-byte logical blocks: (2.00 TB/1.82 TiB)
+      sd 0:0:0:0: [sdb] Write Protect is off
+      sd 0:0:0:0: [sdb] Mode Sense: 00 06 00 00
+      sd 0:0:0:0: [sdb] Write cache: disabled, read cache: enabled, doesn't support DPO or FUA
+      scsi 0:0:24:0: Attached scsi generic sg2 type 3
+      sr 0:1:0:0: [sr0] scsi-1 drive
+      cdrom: Uniform CD-ROM driver Revision: 3.20
+      sr 0:1:0:0: Attached scsi CD-ROM sr0
+      sr 0:1:0:0: Attached scsi generic sg3 type 5
+       sdb: sdb1 sdb2 sdb3
+      sd 0:0:0:0: [sdb] Attached SCSI disk
+
+## More on installation and dual booting with Windows
+
+For a complete and detailed set of instructions on how to install and use the
+AMD RAID Linux driver, have a look at [How to dual boot Windows and Ubuntu on AMD RAID](https://www.kwikr.de//Howto_Windows_Ubuntu_AMD-RAID.html).

--- a/rcraid.patch
+++ b/rcraid.patch
@@ -1,42 +1,54 @@
-diff -r -U3 driver_sdk/install new/driver_sdk/install
---- driver_sdk/install	2016-12-15 20:27:16.000000000 +0100
-+++ new/driver_sdk/install	2018-06-30 17:11:28.196601864 +0200
+diff -r -U3 old/driver_sdk/install new/driver_sdk/install
+--- old/driver_sdk/install	2016-12-15 20:27:16.000000000 +0100
++++ new/driver_sdk/install	2018-09-16 19:18:27.731702569 +0200
 @@ -1,4 +1,4 @@
 -#!/bin/sh
 +#!/bin/bash
  
  #  Script to install the RAIDCore drivers from the SDK for supported platforms
  #  (RedHat and SuSE). 
-diff -r -U3 driver_sdk/src/common_shell new/driver_sdk/src/common_shell
---- driver_sdk/src/common_shell	2016-12-15 20:27:22.000000000 +0100
-+++ new/driver_sdk/src/common_shell	2018-06-30 17:12:37.584197823 +0200
+diff -r -U3 old/driver_sdk/src/Makefile new/driver_sdk/src/Makefile
+--- old/driver_sdk/src/Makefile	2016-12-15 20:27:24.000000000 +0100
++++ new/driver_sdk/src/Makefile	2018-09-16 19:23:53.122266046 +0200
+@@ -20,7 +20,7 @@
+ RC_USER=$(shell whoami)
+ RC_DATE=$(shell /bin/date)
+ RC_BUILD_DATE=$(shell /bin/date +'%b %d %Y')
+-PLATFORM=$(shell uname -i)
++PLATFORM=$(shell uname -m)
+ 
+ EXTRA_CFLAGS += -D__LINUX__
+ EXTRA_CFLAGS += -DRC_AHCI_SUPPORT -DRC_AMD_AHCI -DRC_AHCI_AUTOSENSE
+diff -r -U3 old/driver_sdk/src/common_shell new/driver_sdk/src/common_shell
+--- old/driver_sdk/src/common_shell	2016-12-15 20:27:22.000000000 +0100
++++ new/driver_sdk/src/common_shell	2018-09-16 19:18:27.731702569 +0200
 @@ -1,4 +1,4 @@
 -#!/bin/sh
 +#!/bin/bash
  
  # Common shell routines used by the top level install script (SDK and driver
  # disks) and also from the OS specific scripts in the SDK (also contains
-diff -r -U3 driver_sdk/src/install_rh new/driver_sdk/src/install_rh
---- driver_sdk/src/install_rh	2016-12-15 20:27:24.000000000 +0100
-+++ new/driver_sdk/src/install_rh	2018-06-30 17:12:54.536064242 +0200
+diff -r -U3 old/driver_sdk/src/install_rh new/driver_sdk/src/install_rh
+--- old/driver_sdk/src/install_rh	2016-12-15 20:27:24.000000000 +0100
++++ new/driver_sdk/src/install_rh	2018-09-16 19:18:27.731702569 +0200
 @@ -1,4 +1,4 @@
 -#!/bin/sh 
 +#!/bin/bash
  
  #  Script to install the driver into the /lib/modules tree for RedHat distros. 
  #  By default new drivers will be installed for the currently running kernel.
-diff -r -U3 driver_sdk/src/install_suse new/driver_sdk/src/install_suse
---- driver_sdk/src/install_suse	2016-12-15 20:27:24.000000000 +0100
-+++ new/driver_sdk/src/install_suse	2018-06-30 17:13:07.755952816 +0200
+diff -r -U3 old/driver_sdk/src/install_suse new/driver_sdk/src/install_suse
+--- old/driver_sdk/src/install_suse	2016-12-15 20:27:24.000000000 +0100
++++ new/driver_sdk/src/install_suse	2018-09-16 19:18:27.731702569 +0200
 @@ -1,4 +1,4 @@
 -#!/bin/sh 
 +#!/bin/bash
  
  #  Script to install the driver into the /lib/modules tree for SuSE distros. 
  #  By default new drivers will be installed for the currently running kernel.
-diff -r -U3 driver_sdk/src/rc_init.c new/driver_sdk/src/rc_init.c
---- driver_sdk/src/rc_init.c	2016-12-15 20:27:32.000000000 +0100
-+++ new/driver_sdk/src/rc_init.c	2018-06-12 22:19:05.274770329 +0200
+diff -r -U3 old/driver_sdk/src/rc_init.c new/driver_sdk/src/rc_init.c
+--- old/driver_sdk/src/rc_init.c	2016-12-15 20:27:32.000000000 +0100
++++ new/driver_sdk/src/rc_init.c	2018-09-16 19:18:27.731702569 +0200
 @@ -169,7 +169,11 @@
  void        rc_dump_scp(struct scsi_cmnd * scp);
  const char *rc_info(struct Scsi_Host *host_ptr);
@@ -87,9 +99,9 @@ diff -r -U3 driver_sdk/src/rc_init.c new/driver_sdk/src/rc_init.c
  	add_timer(&state->rc_timeout);
  	down(&state->rc_timeout_sema);
  }
-diff -r -U3 driver_sdk/src/rc_mem_ops.c new/driver_sdk/src/rc_mem_ops.c
---- driver_sdk/src/rc_mem_ops.c	2016-12-15 20:27:34.000000000 +0100
-+++ new/driver_sdk/src/rc_mem_ops.c	2018-06-12 22:19:05.342770084 +0200
+diff -r -U3 old/driver_sdk/src/rc_mem_ops.c new/driver_sdk/src/rc_mem_ops.c
+--- old/driver_sdk/src/rc_mem_ops.c	2016-12-15 20:27:34.000000000 +0100
++++ new/driver_sdk/src/rc_mem_ops.c	2018-09-16 19:18:27.731702569 +0200
 @@ -19,6 +19,7 @@
   *
   ****************************************************************************/
@@ -98,9 +110,9 @@ diff -r -U3 driver_sdk/src/rc_mem_ops.c new/driver_sdk/src/rc_mem_ops.c
  #include "linux/vmalloc.h"
  #include "linux/wait.h"
  #include "linux/sched.h"
-diff -r -U3 driver_sdk/src/rc_msg.c new/driver_sdk/src/rc_msg.c
---- driver_sdk/src/rc_msg.c	2016-12-15 20:27:34.000000000 +0100
-+++ new/driver_sdk/src/rc_msg.c	2018-06-12 22:19:05.350770055 +0200
+diff -r -U3 old/driver_sdk/src/rc_msg.c new/driver_sdk/src/rc_msg.c
+--- old/driver_sdk/src/rc_msg.c	2016-12-15 20:27:34.000000000 +0100
++++ new/driver_sdk/src/rc_msg.c	2018-09-16 19:18:27.731702569 +0200
 @@ -37,10 +37,18 @@
  
  void rc_msg_send_srb_function (rc_softstate_t *state, int function_code);
@@ -212,27 +224,27 @@ diff -r -U3 driver_sdk/src/rc_msg.c new/driver_sdk/src/rc_msg.c
  	add_timer(&state->msg_timeout);
  	down(&state->msg_timeout_sema);
  
-diff -r -U3 driver_sdk/src/uninstall_rh new/driver_sdk/src/uninstall_rh
---- driver_sdk/src/uninstall_rh	2016-12-15 20:27:38.000000000 +0100
-+++ new/driver_sdk/src/uninstall_rh	2018-06-30 17:13:37.483682373 +0200
+diff -r -U3 old/driver_sdk/src/uninstall_rh new/driver_sdk/src/uninstall_rh
+--- old/driver_sdk/src/uninstall_rh	2016-12-15 20:27:38.000000000 +0100
++++ new/driver_sdk/src/uninstall_rh	2018-09-16 19:18:27.735702732 +0200
 @@ -1,4 +1,4 @@
 -#!/bin/sh
 +#!/bin/bash
  
  #
  # Script to remove the driver(s) from an existing SuSE linux install
-diff -r -U3 driver_sdk/src/uninstall_suse new/driver_sdk/src/uninstall_suse
---- driver_sdk/src/uninstall_suse	2016-12-15 20:27:38.000000000 +0100
-+++ new/driver_sdk/src/uninstall_suse	2018-06-30 17:13:47.011590619 +0200
+diff -r -U3 old/driver_sdk/src/uninstall_suse new/driver_sdk/src/uninstall_suse
+--- old/driver_sdk/src/uninstall_suse	2016-12-15 20:27:38.000000000 +0100
++++ new/driver_sdk/src/uninstall_suse	2018-09-16 19:18:27.735702732 +0200
 @@ -1,4 +1,4 @@
 -#!/bin/sh 
 +#!/bin/bash
  #
  # Script to remove the driver(s) from an existing SuSE linux install
  # 
-diff -r -U3 driver_sdk/uninstall new/driver_sdk/uninstall
---- driver_sdk/uninstall	2016-12-15 20:27:18.000000000 +0100
-+++ new/driver_sdk/uninstall	2018-06-30 17:11:38.232560682 +0200
+diff -r -U3 old/driver_sdk/uninstall new/driver_sdk/uninstall
+--- old/driver_sdk/uninstall	2016-12-15 20:27:18.000000000 +0100
++++ new/driver_sdk/uninstall	2018-09-16 19:18:27.735702732 +0200
 @@ -1,4 +1,4 @@
 -#!/bin/sh
 +#!/bin/bash


### PR DESCRIPTION
Replaced `uname -i` to `uname -m` in Makefile for platform detection, since `uname -i` is not portable across Linux flavors. Also added CHANGELOG.md and updated README.md.