### PR TITLE
Missing symbols in rcraid.ko

### DIFF
--- a/rcraid.patch
+++ b/rcraid.patch
@@ -9,7 +9,7 @@ diff -r -U3 old/driver_sdk/install new/driver_sdk/install
  #  (RedHat and SuSE). 
 diff -r -U3 old/driver_sdk/src/Makefile new/driver_sdk/src/Makefile
 --- old/driver_sdk/src/Makefile	2016-12-15 20:27:24.000000000 +0100
-+++ new/driver_sdk/src/Makefile	2018-09-16 22:30:34.801569166 +0200
++++ new/driver_sdk/src/Makefile	2019-02-17 14:26:25.377337830 +0100
 @@ -20,7 +20,7 @@
  RC_USER=$(shell whoami)
  RC_DATE=$(shell /bin/date)
@@ -19,6 +19,25 @@ diff -r -U3 old/driver_sdk/src/Makefile new/driver_sdk/src/Makefile
  
  EXTRA_CFLAGS += -D__LINUX__
  EXTRA_CFLAGS += -DRC_AHCI_SUPPORT -DRC_AMD_AHCI -DRC_AHCI_AUTOSENSE
+@@ -89,7 +89,7 @@
+ 
+ obj-m := rcraid.o
+ 
+-rcraid-objs := rc_init.o rc_msg.o rc_mem_ops.o rc_event.o rc_config.o rcblob.${PLATFORM} \
++rcraid-objs := rc_init.o rc_msg.o rc_mem_ops.o rc_event.o rc_config.o rcblob.${PLATFORM}.o \
+ 	       vers.o
+ 
+ .PHONY:	$(obj)/vers.c
+@@ -98,6 +98,7 @@
+ 
+ # hack to avoid warning about missing .rcblob.cmd file when modpost tries to
+ # find all the sources
+-.PHONY: $(obj)/rcblob.${PLATFORM}
+-$(obj)/rcblob.${PLATFORM}:
++.PHONY: $(obj)/rcblob.${PLATFORM}.o
++$(obj)/rcblob.${PLATFORM}.o:
++	ln -sf `basename $@ .o` $@
+ 	@( echo "cmd_$@ := true"; echo "dep_$@ := \\"; echo "	$@ \\"; echo "" ) > $(obj)/.`basename $@`.cmd
 diff -r -U3 old/driver_sdk/src/common_shell new/driver_sdk/src/common_shell
 --- old/driver_sdk/src/common_shell	2016-12-15 20:27:22.000000000 +0100
 +++ new/driver_sdk/src/common_shell	2018-09-16 22:30:34.801569166 +0200


### PR DESCRIPTION
Due to changes to the kernel build system, the rcblob was not picked up in the
linking stage, leading to missing symbols in the rcraid.ko kernel module.
Fixed by changing Makefile destinations and rules.